### PR TITLE
Check nil pointer

### DIFF
--- a/check.go
+++ b/check.go
@@ -101,8 +101,9 @@ func orderedPkgs(prog *loader.Program) ([]*types.Package, error) {
 	sort.Sort(ByAlph(paths))
 	var pkgs []*types.Package
 	for _, path := range paths {
-		info := prog.Package(path)
-		pkgs = append(pkgs, info.Pkg)
+		if info := prog.Package(path); info != nil {
+			pkgs = append(pkgs, info.Pkg)
+		}
 	}
 	return pkgs, nil
 }


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x47db18]

goroutine 1 [running]:
github.com/mvdan/interfacer.orderedPkgs(0xc0820075c0, 0x0, 0x0, 0x0, 0x0, 0x0)
        c:/dev/godev/src/github.com/mvdan/interfacer/check.go:105 +0x328
github.com/mvdan/interfacer.CheckArgs(0xc0820046f0, 0x1, 0x1, 0xaa46f0, 0xc082022010, 0x404400, 0x0, 0x0)
        c:/dev/godev/src/github.com/mvdan/interfacer/check.go:123 +0x1c8
main.main()
        c:/dev/godev/src/github.com/mvdan/interfacer/cmd/interfacer/main.go:20 +0xab
```
