### PR TITLE
README: Skip /vendor/ folders in usage example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ func ProcessInput(f *os.File) error {
 ```
 
 ```sh
-$ interfacer ./...
+$ interfacer $(go list ./... | grep -v /vendor/)
 foo.go:10:19: f can be io.Reader
 ```
 


### PR DESCRIPTION
This is a better default usage example. Most people want to run the tool on code they control, not vendored code that cannot be modified.

Updates #27.
Fixes #29.